### PR TITLE
Quick fix for spi_read('RegFifo', 1) - if length=1 then function retu…

### DIFF
--- a/lora.py
+++ b/lora.py
@@ -233,11 +233,11 @@ class SX1276:
         self.spi.write(data)
         self.cs_pin.value(1) # release the bus.
 
-    def spi_read(self, reg=None, length=1):
+    def spi_read(self, reg=None, length=None):
         self.cs_pin.value(0)
         # https://docs.micropython.org/en/latest/library/machine.SPI.html#machine-softspi
-        if length == 1:
-            data = self.spi.read(length+1, self.RegTable[reg])[1]
+        if length is None:
+            data = self.spi.read(2, self.RegTable[reg])[1]
         else:
             data = self.spi.read(length+1, self.RegTable[reg])[1:]
         self.cs_pin.value(1)


### PR DESCRIPTION
This is a quick fix for reading 1 byte length packet data from RegFifo:

```
def read_fifo(self):
        packet     = self.spi_read('RegFifo', self.spi_read('RegRxNbBytes'))
```
When length is 1, then packet was ``int`` type....

```
def _irq_handler(self, pin):
        packet, SNR, RSSI, CR               = self.read_fifo() # read fifo
        if len(packet) < self.header_size:  ### TypeError: object of type 'int' has no len()
```

So cannot use ``len`` function or iterate over elements.
